### PR TITLE
Move config_dir to _parse method to avoid error

### DIFF
--- a/lib/crossplane/parser.rb
+++ b/lib/crossplane/parser.rb
@@ -55,8 +55,6 @@ module CrossPlane
 		end
 
 		def parse(*args, onerror:nil)
-			config_dir = File.dirname(self.filename)
-
 			self.payload = {
 				'status' => 'ok',
 				'errors' => [],
@@ -96,9 +94,10 @@ module CrossPlane
 			end
 
 			def _parse(parsing, tokens, ctx:[], consume: false)
+				config_dir = File.dirname(self.filename)
 				fname = parsing['file']
 				parsed = []
-			
+
 				begin
 					while tuple = tokens.next
 						token, lineno = tuple


### PR DESCRIPTION
Issue: current implementation of [this method](https://github.com/gdanko/crossplane/blob/master/lib/crossplane/parser.rb#L197) uses the `config_dir` local variable which is defined, but in another [method](https://github.com/gdanko/crossplane/blob/master/lib/crossplane/parser.rb#L58). Basically, it doesn't allow to use a relative path for [include](https://nginx.org/en/docs/ngx_core_module.html#include) directive for basic Nginx configuration. 

Each time when I try to use it I face with the following error: `"error":"undefined local variable or method 'config_dir' for #<CrossPlane::Parser:0x00007fb5e821f188>\nDid you mean?  configure_options"`

This PR fixes this small issue. 